### PR TITLE
Handle daily counter as game status

### DIFF
--- a/cmd/shibesbot/discord.go
+++ b/cmd/shibesbot/discord.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -47,9 +46,7 @@ func (sb *Shibesbot) initDiscord() error {
 
 	sb.session.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) { sb.commandPicker(s, i) })
 	sb.session.AddHandlerOnce(func(s *discordgo.Session, i *discordgo.Ready) {
-		t := time.Now()
-		key := fmt.Sprintf("usage:%d%d%d", t.Day(), t.Month(), t.Year())
-		count, err := sb.cache.Get(context.Background(), key)
+		count, err := sb.cache.Get(context.Background(), sb.dailyKey)
 		if err != nil {
 			sb.log.Warn("could not get daily counter from cache : ", err.Error())
 		}
@@ -95,23 +92,27 @@ func (sb *Shibesbot) commandPicker(s *discordgo.Session, i *discordgo.Interactio
 			Content: response,
 		},
 	})
-	count := sb.updateDailyCounter()
-	s.UpdateGameStatus(0, fmt.Sprintf("used %d times today", count))
+
+	sb.updateDailyCounter()
 }
 
-func (sb *Shibesbot) updateDailyCounter() int64 {
-	t := time.Now()
-	key := fmt.Sprintf("usage:%d%d%d", t.Day(), t.Month(), t.Year())
-	count, err := sb.cache.Incr(context.Background(), key)
+func (sb *Shibesbot) updateDailyCounter() {
+	sb.mtx.RLock()
+	defer sb.mtx.RUnlock()
+	count, err := sb.cache.Incr(context.Background(), sb.dailyKey)
 	if err != nil {
 		sb.log.Warn("could not get daily counter from cache : ", err.Error())
-		return 0
+		return
 	}
 	countInt, ok := count.(int64)
 	if !ok {
 		sb.log.Warn("could not get daily counter from cache")
-		return 0
+		return
 	}
 
-	return countInt
+	sb.setDailyCounter(countInt)
+}
+
+func (sb *Shibesbot) setDailyCounter(count int64) {
+	sb.session.UpdateGameStatus(0, fmt.Sprintf("used %d times today", count))
 }

--- a/cmd/shibesbot/discord.go
+++ b/cmd/shibesbot/discord.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -49,9 +50,23 @@ func (sb *Shibesbot) initDiscord() error {
 		count, err := sb.cache.Get(context.Background(), sb.dailyKey)
 		if err != nil {
 			sb.log.Warn("could not get daily counter from cache : ", err.Error())
+			return
 		}
-		s.UpdateGameStatus(0, fmt.Sprintf("used %s times today", count))
+
+		countString, ok := count.(string)
+		if !ok {
+			sb.log.Warn("could not get daily counter from cache : conversion error")
+			return
+		}
+		countInt, err := strconv.Atoi(countString)
+		if err != nil {
+			sb.log.Warn("could not get daily counter from cache : ", err.Error())
+			return
+		}
+
+		sb.setDailyCounter(int64(countInt))
 	})
+
 	if err = sb.session.Open(); err != nil {
 		return err
 	}

--- a/cmd/shibesbot/main.go
+++ b/cmd/shibesbot/main.go
@@ -74,30 +74,30 @@ func initConfiguration() *Shibesbot {
 func main() {
 	sb := initConfiguration()
 	sb.initRequests()
-	sb.log.Info("Starting Shibesbot")
+	sb.log.Info("starting Shibesbot")
 
 	if len(sb.apiConfigurations.discordToken) <= 0 {
-		sb.log.Error("Environnement variable SHIBESBOT_TOKEN is not provided")
+		sb.log.Error("environnement variable SHIBESBOT_TOKEN is not provided")
 		return
 	}
 
 	if err := sb.initDiscord(); err != nil {
-		sb.log.Error("Connexion error: ", err.Error())
+		sb.log.Error("connexion error: ", err.Error())
 		return
 	}
 	defer func() {
 		if err := sb.session.Close(); err != nil {
-			sb.log.Error("Discord session could not close properly:", err.Error())
+			sb.log.Error("discord session could not close properly:", err.Error())
 			return
 		}
 
-		sb.log.Info("Discord session closed successfully")
+		sb.log.Info("discord session closed successfully")
 	}()
 
-	sb.log.Info("Shibesbot OK, ready to nicely bork on people")
+	sb.log.Info("shibesbot OK, ready to nicely bork on people")
 
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
 	<-sc
-	sb.log.Info("Stop signal has been received, stopping Shibesbot..")
+	sb.log.Info("stop signal has been received, stopping Shibesbot..")
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/robfig/cron/v3 v3.0.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -7,4 +7,5 @@ type Cache interface {
 	Get(context.Context, string) (any, error)
 	Set(context.Context, string, string) (any, error)
 	Incr(context.Context, string) (any, error)
+	SetNX(context.Context, string, any) (any, error)
 }

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -44,3 +44,7 @@ func (r *RedisDB) Set(ctx context.Context, k, v string) (any, error) {
 func (r *RedisDB) Incr(ctx context.Context, k string) (any, error) {
 	return r.client.Incr(ctx, k).Result()
 }
+
+func (r *RedisDB) SetNX(ctx context.Context, k string, v any) (any, error) {
+	return r.client.SetNX(ctx, k, v, 0).Result()
+}


### PR DESCRIPTION
Goal is to update the game status of the bot with the number of daily requests

DOD :
- [x] Update Discord game status for every received request
- [x] Update Discord game status after WSAPI OnReady event
- [x] Reset daily counter every day at midnight 

Current optimizations awaiting :
- [x] Generate daily key every day (and not at every request >:()